### PR TITLE
Fixes/ In dark mode move to top button icon not showing.

### DIFF
--- a/components/BackToTop.jsx
+++ b/components/BackToTop.jsx
@@ -26,12 +26,12 @@ const BackToTop = () => {
     <>
       {showButton && (
         <motion.button
-          className="fixed bottom-5 right-5 z-50 p-2 bg-gray-200 rounded-full shadow-md hover:bg-gray-300"
+          className="fixed bottom-5 right-5 z-50 p-2  dark:bg-gray-400 bg-gray-300 rounded-full shadow-md hover:bg-gray-300"
           onClick={scrollToTop}
           whileHover={{ scale: 1.1 }}
           whileTap={{ scale: 0.9 }}
         >
-          <BsFillArrowUpSquareFill size={30} />
+          <BsFillArrowUpSquareFill size={30} style={{color: "black"}}/>
         </motion.button>
       )}
     </>


### PR DESCRIPTION
This PR will fixes #136 In dark mode move to top button icon not showing.

Fixes #136 

![image](https://github.com/GDSC-Jadavpur-University/GDSC-JU-Website/assets/97227305/6cdb8fb9-0906-49af-9fdc-adafd12d3f2b)

Cheers!🍻, Happy coding🤝