### PR TITLE
Events page card placed horizontally for larger device

### DIFF
--- a/pages/events/index.js
+++ b/pages/events/index.js
@@ -21,7 +21,7 @@ function EventPage() {
   return (
     <>
       <CenterLayout>
-        <div className="row">
+        <div className="w-screen flex justify-center items-center flex-wrap">
           {EventData.map((event) => {
             return (
               <EventCard
@@ -40,7 +40,7 @@ function EventPage() {
 }
 
 const EventCard = (props) => (
-  <div className="col-md-4 mb-4">
+  <div className="col-md-4 m-4 ">
     <div className="bg-white rounded-lg shadow-lg">
       <Image
         src={props.image}


### PR DESCRIPTION
#206 

In Events page, Cards are placed horizontally for larger device and vertically for smaller (mobile) device.

![Screenshot 2023-10-09 140316](https://github.com/GDSC-Jadavpur-University/GDSC-JU-Website/assets/78651887/5124f500-8c2c-4dc1-a776-ad7a5fefe6c0)
