### PR TITLE
fixed a typo in the components/footer.jsx

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -6,7 +6,7 @@ import {
   FaInstagram,
   FaLinkedin,
   FaGithub,
-  FaXTwitter,
+  FaTwitter,
 } from "react-icons/fa6";
 
 function Footer() {


### PR DESCRIPTION
The site was not running because of that typo error, please merge this pr with the hactoberfest lable.
this was the issue
![Screenshot 2023-10-11 032609](https://github.com/GDSC-Jadavpur-University/GDSC-JU-Website/assets/120103598/1991676d-0491-407c-8f9f-8fa8609f5ffb)
 