### PR TITLE
allign-FAQ-section

### DIFF
--- a/components/FAQS.jsx
+++ b/components/FAQS.jsx
@@ -15,7 +15,7 @@ export default function FAQS() {
     <div>
       <Divider className="my-10" />
 
-    <div>
+    <div className="md:px-5 w-[95%] lg:w-[90%] relative mx-auto lg:mt-20 md:mt-[100px]">
       <div className="flex justify-center flex-col">
           <p className="font-semibold text-5xl md:text-3xl mb-10 md:mb-5 leading-[4.8rem] ">
             <strong className="font-bold">


### PR DESCRIPTION
Earlier the FAQS-section was not aligned with the above fields.
<img width="920" alt="Screenshot 2023-10-15 184148" src="https://github.com/GDSC-Jadavpur-University/GDSC-JU-Website/assets/142415456/bc1dda9f-d670-4ba0-a40a-541359a576bf">

Now it is aligned .
<img width="325" alt="Screenshot 2023-10-15 193924" src="https://github.com/GDSC-Jadavpur-University/GDSC-JU-Website/assets/142415456/6839cdbb-f2a9-455a-b5a1-48bf820e5931">

<img width="465" alt="Screenshot 2023-10-15 194039" src="https://github.com/GDSC-Jadavpur-University/GDSC-JU-Website/assets/142415456/7d010206-3290-41bb-b6fd-898a285f82c8">
